### PR TITLE
Fix CI by removing invalid conditional end keyword fi

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,7 +41,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install libasound2-dev
-          fi
       - name: Install ${{ matrix.rust }} toolchain
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
This should hopefully fix the broken Ubuntu GNU/Linux CI build. I was not able to figure out how to test it on my own fork, so it may run into other errors.